### PR TITLE
Set PATH/ENTRYPOINT as appropriate; package fastqc also

### DIFF
--- a/cloud/docker/busco/Dockerfile
+++ b/cloud/docker/busco/Dockerfile
@@ -17,18 +17,19 @@ RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
 
 WORKDIR /opt
 
-RUN curl http://bioinf.uni-greifswald.de/augustus/binaries/augustus-3.3.tar.gz | tar xzf -
+# 3.3 got stuck at 100% cpu on pichia
+RUN curl http://bioinf.uni-greifswald.de/augustus/binaries/old/augustus-3.2.3.tar.gz | tar xzf -
 
 RUN git clone https://gitlab.com/ezlab/busco.git
 
-RUN cd busco && python3 setup.py install --user
+RUN cd busco && git checkout 3.0.2 && python3 setup.py install --user
 
-RUN cd augustus && make
+RUN mv augustus-3.2.3 augustus && cd augustus && make
 
 # Use a custom file, but don't overwrite the default one in case people want to compare.
 COPY busco/busco-config.ini /opt/busco/config/docker-config.ini
 ENV BUSCO_CONFIG_FILE=/opt/busco/config/docker-config.ini
 
 ENV AUGUSTUS_CONFIG_PATH=/opt/augustus/config
-ENV PATH "$PATH:/opt/augustus/bin:/opt/augustus/scripts"
+ENV PATH "$PATH:/opt/augustus/bin:/opt/augustus/scripts:/opt/busco/scripts"
 

--- a/cloud/docker/fastqc/Dockerfile
+++ b/cloud/docker/fastqc/Dockerfile
@@ -1,0 +1,20 @@
+FROM ubuntu:18.04
+
+RUN apt-get update && apt-get install -y software-properties-common
+
+RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9 \
+    && apt-add-repository 'deb http://repos.azulsystems.com/ubuntu stable main'
+
+RUN apt-get update && apt-get -y install \
+    curl \
+    unzip \
+    libfindbin-libs-perl \
+    zulu-9
+
+RUN cd /opt \
+    && curl http://www.bioinformatics.babraham.ac.uk/projects/fastqc/fastqc_v0.11.7.zip -o fastqc.zip \
+    && unzip fastqc.zip \
+    && rm fastqc.zip \
+    && chmod a+x /opt/FastQC/fastqc
+
+ENTRYPOINT ["/opt/FastQC/fastqc"]

--- a/cloud/docker/meraculous/Dockerfile
+++ b/cloud/docker/meraculous/Dockerfile
@@ -20,3 +20,5 @@ RUN mkdir /tmp/meraculous \
     && make \
     && make install \
     && rm -rf /tmp/meraculous
+
+ENV PATH "$PATH:/opt/meraculous/bin"

--- a/cloud/docker/quast/Dockerfile
+++ b/cloud/docker/quast/Dockerfile
@@ -27,6 +27,7 @@ RUN mkdir /tmp/quast \
     && curl -L https://downloads.sourceforge.net/project/quast/quast-4.6.3.tar.gz | tar xzf - \
     && cd /tmp/quast/quast-4.6.3 \
     && ./setup.py install \
-    && ./setup.py test
+    && ./setup.py test \
+    && rm -rf /tmp/quast
 
 ENTRYPOINT ["/usr/local/bin/quast.py"]

--- a/cloud/docker/spades/Dockerfile
+++ b/cloud/docker/spades/Dockerfile
@@ -17,3 +17,5 @@ RUN mkdir /tmp/spades \
 
 # scripts use `python`, not a specific version
 RUN update-alternatives --install /usr/bin/python python /usr/bin/python3 1
+
+ENV PATH "$PATH:/opt/spades/bin"

--- a/cloud/docker/sra-tools/Dockerfile
+++ b/cloud/docker/sra-tools/Dockerfile
@@ -8,6 +8,7 @@ RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
 RUN apt-get update && apt-get -y install \
     build-essential \
     git \
+    python3-distutils \
     zulu-9
 
 # ngs build uses `python`, not a specific version
@@ -34,3 +35,5 @@ RUN mkdir /tmp/ncbi \
     && make \
     && make install \
     && rm -rf /tmp/ncbi
+
+ENV PATH="$PATH:/usr/local/ncbi/sra-tools/bin"

--- a/docs/bioinformatics/pichia_pipeline.md
+++ b/docs/bioinformatics/pichia_pipeline.md
@@ -8,7 +8,7 @@ production.
 ## Tool setup
 
 - `sra-tools`: Docker image `biocurious/sra-tools:2.9.0`.
-- `fastqc`: FastQC is so simple it didn't seem worth packaging in Docker. Install an up to date [JVM](http://www.oracle.com/technetwork/java/index.html), then download the [fastqc zip](https://www.bioinformatics.babraham.ac.uk/projects/download.html#fastqc), unzip, and run the `fastqc` perl script in the resulting directory. Since it doesn't have the execute (`x`) bit enabled, you'll need to either `chmod` it or use `perl /path/to/fastqc`.
+- `fastqc`: Build an image via `/cloud/docker`.
 - `spades`: Docker image `biocurious/spades:3.11.1`.
 - `busco`: Build an image via `/cloud/docker`.
 
@@ -38,7 +38,7 @@ access the files outside of that container. See the README in `/cloud/docker` fo
 
 ```
 docker run -i --rm -t -v $BIO_DATA:/data biocurious/sra-tools:2.9.0 \
-    /usr/local/ncbi/sra-tools/bin/fastq-dump \
+    fastq-dump \
     --outdir /data/pichia \
     --gzip \
     --split-files \
@@ -58,7 +58,10 @@ default location, your home directory, to a partition were there is ample space.
 the quality of raw NGS sequencing data.
 
 ```
-fastqc $BIO_DATA/pichia/ERR1294016_1.fastq.gz $BIO_DATA/pichia/ERR1294016_2.fastq.gz -o $BIO_DATA/pichia/fastqc
+docker run -i --rm -t -v $BIO_DATA:/data <fastqc image id>\
+    /data/pichia/ERR1294016_1.fastq.gz \
+    /data/pichia/ERR1294016_2.fastq.gz \
+    -o /data/pichia/fastqc
 ```
 
 For our pichia postoria sample, fastqc shows the sequence length is 50 and there is some duplication. I do not see any bases I want to trim. 
@@ -68,7 +71,7 @@ For our pichia postoria sample, fastqc shows the sequence length is 50 and there
 We select the [SPAdes](http://cab.spbu.ru/software/spades/), St. Petersburg genome assembler.
 
 ```
-docker run -i --rm -v $BIO_DATA:/data -t biocurious/spades:3.11.1 /opt/spades/bin/spades.py \
+docker run -i --rm -v $BIO_DATA:/data -t biocurious/spades:3.11.1 spades.py \
     -o /data/pichia/assembly \
     -1 /data/pichia/ERR1294016_1.fastq.gz \
     -2 /data/pichia/ERR1294016_2.fastq.gz
@@ -92,7 +95,7 @@ cd $BIO_DATA/pichia && curl http://busco.ezlab.org/datasets/saccharomycetales_od
 Then we can run BUSCO. 
 
 ```
-docker run -i --rm -v $BIO_DATA:/data -t <busco image id> /opt/busco/scripts/run_BUSCO.py \
+docker run -i --rm -v $BIO_DATA:/data -t <busco image id> run_BUSCO.py \
     -m genome \
     --in /data/pichia/assembly/scaffolds.fasta \
     --out busco-pichia \


### PR DESCRIPTION
This means the command line invocations can be a bit shorter.

Also, since fastqc turned out to be a pain to set up on that VM in the demo recording, figured I might as well throw in a build for that as well.

Once someone other than me runs through these instructions, I'll publish images for all of these on docker hub so people won't need to build them.